### PR TITLE
replace missing ui components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Progress } from "@/components/ui/progress";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Label } from "@/components/ui/label";
+import { Progress } from "./components/ui/progress";
+import { Button } from "./components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
+import { Badge } from "./components/ui/badge";
+import { Input } from "./components/ui/input";
+import { Label } from "./components/ui/label";
 import { Sparkles, RotateCcw, Check, X, Trophy, BookOpenText, Gamepad2, Brain, Upload, Download, Headphones, Shuffle, HelpCircle } from "lucide-react";
 
 import { ConfettiBurst } from "./components/ConfettiBurst";
@@ -221,34 +220,40 @@ export default function App() {
           <CardContent className="grid gap-4 p-4 md:grid-cols-4">
             <div>
               <Label className="mb-1 block text-sm">Режим</Label>
-              <Select value={mode} onValueChange={(v: any) => setMode(v)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="multiple">Тест (4 варианта)</SelectItem>
-                  <SelectItem value="sr_to_ru">SR → RU (ввод)</SelectItem>
-                  <SelectItem value="ru_to_sr">RU → SR (ввод)</SelectItem>
-                  <SelectItem value="typing">Слепой набор</SelectItem>
-                  <SelectItem value="true_false">Правда/ложь</SelectItem>
-                  <SelectItem value="scramble">Собери слово</SelectItem>
-                  <SelectItem value="audio">Аудио (произношение)</SelectItem>
-                </SelectContent>
-              </Select>
+              <select
+                value={mode}
+                onChange={(e) => setMode(e.target.value as Mode)}
+                className="w-full rounded border p-2"
+              >
+                <option value="multiple">Тест (4 варианта)</option>
+                <option value="sr_to_ru">SR → RU (ввод)</option>
+                <option value="ru_to_sr">RU → SR (ввод)</option>
+                <option value="typing">Слепой набор</option>
+                <option value="true_false">Правда/ложь</option>
+                <option value="scramble">Собери слово</option>
+                <option value="audio">Аудио (произношение)</option>
+              </select>
             </div>
             <div>
               <Label className="mb-1 block text-sm">Сложность</Label>
               <div className="flex items-center gap-3">
-                <Select
+                <select
                   value={String(difficulty)}
-                  onValueChange={(v) => {
+                  onChange={(e) => {
+                    const v = Number(e.target.value);
                     setAutoDifficulty(false);
-                    setDifficulty(Number(v));
-                    nextRound(Number(v));
+                    setDifficulty(v);
+                    nextRound(v);
                   }}
                   disabled={autoDifficulty}
+                  className="rounded border p-2"
                 >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>{[1,2,3,4,5].map((n)=> <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
-                </Select>
+                  {[1, 2, 3, 4, 5].map((n) => (
+                    <option key={n} value={String(n)}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
                 <Button variant={autoDifficulty ? "default" : "outline"} size="sm" onClick={() => setAutoDifficulty((s) => !s)}>
                   <Brain className="mr-2 h-4 w-4" /> {autoDifficulty ? "Авто" : "Вручную"}
                 </Button>

--- a/src/components/AddWordForm.tsx
+++ b/src/components/AddWordForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
 import { Word } from "../types";
 
 export function AddWordForm({ onAdd }: { onAdd: (w: Word) => void }) {
@@ -14,10 +13,17 @@ export function AddWordForm({ onAdd }: { onAdd: (w: Word) => void }) {
       <div className="grid gap-2 md:grid-cols-4">
         <Input placeholder="sr/cr (latin)" value={sr} onChange={(e) => setSr(e.target.value)} />
         <Input placeholder="русский" value={ru} onChange={(e) => setRu(e.target.value)} />
-        <Select value={lvl} onValueChange={setLvl}>
-          <SelectTrigger><SelectValue placeholder="lvl" /></SelectTrigger>
-          <SelectContent>{[1,2,3,4,5].map((n)=> <SelectItem key={n} value={String(n)}>{n}</SelectItem>)}</SelectContent>
-        </Select>
+        <select
+          value={lvl}
+          onChange={(e) => setLvl(e.target.value)}
+          className="rounded border p-2"
+        >
+          {[1, 2, 3, 4, 5].map((n) => (
+            <option key={n} value={String(n)}>
+              {n}
+            </option>
+          ))}
+        </select>
         <Input placeholder="тег" value={tag} onChange={(e) => setTag(e.target.value)} />
       </div>
       <div className="flex justify-end">

--- a/src/components/CsvImport.tsx
+++ b/src/components/CsvImport.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
 import { Word } from "../types";
 import { clamp } from "../utils";
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: string;
+}
+
+export function Badge({ children, ...props }: BadgeProps) {
+  return <span {...props}>{children}</span>;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: string;
+  size?: string;
+}
+
+export function Button({ children, ...props }: ButtonProps) {
+  return <button {...props}>{children}</button>;
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export function Card({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}
+
+export function CardHeader({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}
+
+export function CardTitle({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 {...props}>{children}</h3>;
+}
+
+export function CardContent({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  return <input ref={ref} {...props} />;
+});
+
+Input.displayName = "Input";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export function Label({ children, ...props }: LabelProps) {
+  return <label {...props}>{children}</label>;
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export function Progress({ value = 0 }: { value?: number }) {
+  return (
+    <div className="w-full bg-gray-200 rounded">
+      <div className="bg-blue-500 h-2 rounded" style={{ width: `${value}%` }} />
+    </div>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface TabsContextProps {
+  value: string;
+  setValue: (v: string) => void;
+}
+
+const TabsContext = createContext<TabsContextProps | undefined>(undefined);
+
+export function Tabs({ defaultValue, children }: { defaultValue: string; children: React.ReactNode }) {
+  const [value, setValue] = useState(defaultValue);
+  return <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>;
+}
+
+export function TabsList({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div {...props}>{children}</div>;
+}
+
+export function TabsTrigger({ value, children, ...props }: { value: string; children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const ctx = useContext(TabsContext);
+  if (!ctx) return null;
+  return (
+    <button onClick={() => ctx.setValue(value)} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({ value, children, ...props }: { value: string; children: React.ReactNode } & React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = useContext(TabsContext);
+  if (!ctx || ctx.value !== value) return null;
+  return <div {...props}>{children}</div>;
+}


### PR DESCRIPTION
## Summary
- replace `@/components/ui` imports with local components
- implement minimal Button, Card, Tabs, Badge, Input, Label, and Progress components
- use native `<select>` elements for mode and difficulty controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897715605908325a34ca50111ac7b76