### PR TITLE
style: modernize ui and hide sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,9 +194,8 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-b from-white to-sky-50 p-4 md:p-8">
-      <div className="mx-auto max-w-5xl">
-        {/* Header */}
+    <div className="app-container">
+      {/* Header */}
         <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <motion.div initial={{ rotate: -10, scale: 0.9 }} animate={{ rotate: 0, scale: 1 }} transition={{ type: "spring", stiffness: 200 }} className="rounded-2xl bg-sky-600 p-3 text-white shadow">
@@ -371,7 +370,7 @@ export default function App() {
         </Card>
 
         {/* Dictionary & Import */}
-        <Tabs defaultValue="dict" className="mt-8">
+        <Tabs defaultValue="" className="mt-8">
           <TabsList>
             <TabsTrigger value="dict">Словарь</TabsTrigger>
             <TabsTrigger value="about">О приложении</TabsTrigger>
@@ -438,7 +437,6 @@ export default function App() {
         </Tabs>
 
         <footer className="mt-10 pb-8 text-center text-xs text-slate-500">Made for fast daily drills • 🇲🇪🇷🇸 Latinica</footer>
-      </div>
     </div>
   );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,6 +4,10 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: string;
 }
 
-export function Badge({ children, ...props }: BadgeProps) {
-  return <span {...props}>{children}</span>;
+export function Badge({ children, className = "", ...props }: BadgeProps) {
+  return (
+    <span className={`badge ${className}`.trim()} {...props}>
+      {children}
+    </span>
+  );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,6 +5,13 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   size?: string;
 }
 
-export function Button({ children, ...props }: ButtonProps) {
-  return <button {...props}>{children}</button>;
+export function Button({ children, className = "", ...props }: ButtonProps) {
+  return (
+    <button
+      className={`btn ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,17 +1,33 @@
 import React from "react";
 
-export function Card({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div {...props}>{children}</div>;
+export function Card({ children, className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`card ${className}`.trim()} {...props}>
+      {children}
+    </div>
+  );
 }
 
-export function CardHeader({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div {...props}>{children}</div>;
+export function CardHeader({ children, className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`card-header ${className}`.trim()} {...props}>
+      {children}
+    </div>
+  );
 }
 
-export function CardTitle({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 {...props}>{children}</h3>;
+export function CardTitle({ children, className = "", ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3 className={`card-title ${className}`.trim()} {...props}>
+      {children}
+    </h3>
+  );
 }
 
-export function CardContent({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div {...props}>{children}</div>;
+export function CardContent({ children, className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`card-content ${className}`.trim()} {...props}>
+      {children}
+    </div>
+  );
 }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,10 @@ import React from "react";
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
-  return <input ref={ref} {...props} />;
-});
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className = "", ...props }, ref) => {
+    return <input ref={ref} className={`input ${className}`.trim()} {...props} />;
+  }
+);
 
 Input.displayName = "Input";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -2,6 +2,10 @@ import React from "react";
 
 export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
 
-export function Label({ children, ...props }: LabelProps) {
-  return <label {...props}>{children}</label>;
+export function Label({ children, className = "", ...props }: LabelProps) {
+  return (
+    <label className={`label ${className}`.trim()} {...props}>
+      {children}
+    </label>
+  );
 }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export function Progress({ value = 0 }: { value?: number }) {
   return (
-    <div className="w-full bg-gray-200 rounded">
-      <div className="bg-blue-500 h-2 rounded" style={{ width: `${value}%` }} />
+    <div className="progress">
+      <div className="progress-bar" style={{ width: `${value}%` }} />
     </div>
   );
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,15 +12,25 @@ export function Tabs({ defaultValue, children }: { defaultValue: string; childre
   return <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>;
 }
 
-export function TabsList({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div {...props}>{children}</div>;
+export function TabsList({ children, className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`tabs-list ${className}`.trim()} {...props}>
+      {children}
+    </div>
+  );
 }
 
 export function TabsTrigger({ value, children, ...props }: { value: string; children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   const ctx = useContext(TabsContext);
   if (!ctx) return null;
+  const { value: current, setValue } = ctx;
+  const active = current === value;
   return (
-    <button onClick={() => ctx.setValue(value)} {...props}>
+    <button
+      className={`tab-trigger ${active ? "active" : ""} ${props.className || ""}`.trim()}
+      onClick={() => setValue(value)}
+      {...props}
+    >
       {children}
     </button>
   );
@@ -29,5 +39,9 @@ export function TabsTrigger({ value, children, ...props }: { value: string; chil
 export function TabsContent({ value, children, ...props }: { value: string; children: React.ReactNode } & React.HTMLAttributes<HTMLDivElement>) {
   const ctx = useContext(TabsContext);
   if (!ctx || ctx.value !== value) return null;
-  return <div {...props}>{children}</div>;
+  return (
+    <div className={`tab-content ${props.className || ""}`.trim()} {...props}>
+      {children}
+    </div>
+  );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,88 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(135deg, #f0f4ff, #d9e8ff);
+  min-height: 100vh;
+}
+.app-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+.card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+.card-header {
+  margin-bottom: 0.5rem;
+}
+.card-title {
+  margin: 0 0 0.5rem;
+}
+.btn {
+  background: linear-gradient(135deg, #4f46e5, #9333ea);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.btn:hover {
+  opacity: 0.9;
+}
+.input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  width: 100%;
+  font-size: 1rem;
+}
+.label {
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+  display: block;
+}
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  background: #e0e7ff;
+}
+.tabs-list {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 2rem;
+}
+.tab-trigger {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 8px;
+  background: #e5e7eb;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.tab-trigger.active {
+  background: linear-gradient(135deg, #4f46e5, #9333ea);
+  color: #fff;
+}
+.tab-content {
+  margin-top: 1rem;
+}
+.progress {
+  width: 100%;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+  height: 8px;
+}
+.progress-bar {
+  background: linear-gradient(135deg, #4f46e5, #9333ea);
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- apply gradient background and rounded components via new shared CSS
- unify button and input components with modern styling
- hide dictionary, about, and sync sections until tabs are activated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898839abf44832598de274d08e39426